### PR TITLE
executor: Improve error handling

### DIFF
--- a/abstract_test.go
+++ b/abstract_test.go
@@ -355,19 +355,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
     }`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"pets": []interface{}{
-				map[string]interface{}{
-					"name":  "Odie",
-					"woofs": bool(true),
-				},
-				map[string]interface{}{
-					"name":  "Garfield",
-					"meows": bool(false),
-				},
-				nil,
-			},
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message:   `Runtime Object type "Human" is not a possible type for "Pet".`,
@@ -473,19 +461,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
     }`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"pets": []interface{}{
-				map[string]interface{}{
-					"name":  "Odie",
-					"woofs": bool(true),
-				},
-				map[string]interface{}{
-					"name":  "Garfield",
-					"meows": bool(false),
-				},
-				nil,
-			},
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message:   `Runtime Object type "Human" is not a possible type for "Pet".`,

--- a/executor_test.go
+++ b/executor_test.go
@@ -510,17 +510,11 @@ func TestNullsOutErrorSubtrees(t *testing.T) {
       syncError,
     }`
 
-	expectedData := map[string]interface{}{
-		"sync":      "sync",
-		"syncError": nil,
-	}
 	expectedErrors := []gqlerrors.FormattedError{
 		{
 			Message: "Error getting syncError",
 			Locations: []location.SourceLocation{
-				{
-					Line: 3, Column: 7,
-				},
+				{Line: 3, Column: 7},
 			},
 		},
 	}
@@ -529,8 +523,8 @@ func TestNullsOutErrorSubtrees(t *testing.T) {
 		"sync": func() interface{} {
 			return "sync"
 		},
-		"syncError": func() interface{} {
-			panic("Error getting syncError")
+		"syncError": func() (interface{}, error) {
+			return nil, errors.New("Error getting syncError")
 		},
 	}
 	schema, err := graphql.NewSchema(graphql.SchemaConfig{
@@ -563,11 +557,11 @@ func TestNullsOutErrorSubtrees(t *testing.T) {
 	if len(result.Errors) == 0 {
 		t.Fatalf("wrong result, expected errors, got %v", len(result.Errors))
 	}
-	if !reflect.DeepEqual(expectedData, result.Data) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedData, result.Data))
+	if result.Data != nil {
+		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(nil, result.Data))
 	}
 	if !reflect.DeepEqual(expectedErrors, result.Errors) {
-		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expectedErrors, result.Errors))
+		t.Fatalf("Unexpected result, \nActual: %#v\nExpected:%#v\nDiff: %v", result.Errors, expectedErrors, testutil.Diff(expectedErrors, result.Errors))
 	}
 }
 
@@ -1293,14 +1287,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 	}
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"specials": []interface{}{
-				map[string]interface{}{
-					"value": "foo",
-				},
-				nil,
-			},
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message:   `Expected value of type "SpecialType" but got: graphql_test.testNotSpecialType.`,

--- a/lists_test.go
+++ b/lists_test.go
@@ -48,7 +48,7 @@ func checkList(t *testing.T, testType graphql.Type, testData interface{}, expect
 	}
 	result := testutil.TestExecute(t, ep)
 	if len(expected.Errors) != len(result.Errors) {
-		t.Fatalf("wrong result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
+		t.Fatalf("wrong result, Expected: %#v, Got: %#v", expected.Errors, result.Errors)
 	}
 	if !reflect.DeepEqual(expected, result) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
@@ -251,9 +251,7 @@ func TestLists_NonNullListOfNullableObjectsContainsNull(t *testing.T) {
 func TestLists_NonNullListOfNullableObjectsReturnsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.Int))
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: "Cannot return null for non-nullable field DataType.test.",
@@ -321,9 +319,7 @@ func TestLists_NonNullListOfNullableFunc_ReturnsNull(t *testing.T) {
 		return nil
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: "Cannot return null for non-nullable field DataType.test.",
@@ -415,11 +411,7 @@ func TestLists_NullableListOfNonNullObjects_ContainsNull(t *testing.T) {
 		1, nil, 2,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": nil,
-			},
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: "Cannot return null for non-nullable field DataType.test.",
@@ -480,11 +472,7 @@ func TestLists_NullableListOfNonNullFunc_ContainsNull(t *testing.T) {
 		}
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": nil,
-			},
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: "Cannot return null for non-nullable field DataType.test.",
@@ -593,9 +581,7 @@ func TestLists_NonNullListOfNonNullObjects_ContainsNull(t *testing.T) {
 		1, nil, 2,
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: "Cannot return null for non-nullable field DataType.test.",
@@ -614,9 +600,7 @@ func TestLists_NonNullListOfNonNullObjects_ReturnsNull(t *testing.T) {
 	ttype := graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(graphql.Int)))
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: "Cannot return null for non-nullable field DataType.test.",
@@ -665,9 +649,7 @@ func TestLists_NonNullListOfNonNullFunc_ContainsNull(t *testing.T) {
 		}
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: "Cannot return null for non-nullable field DataType.test.",
@@ -691,9 +673,7 @@ func TestLists_NonNullListOfNonNullFunc_ReturnsNull(t *testing.T) {
 		return nil
 	}
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: "Cannot return null for non-nullable field DataType.test.",
@@ -766,11 +746,7 @@ func TestLists_UserErrorExpectIterableButDidNotGetOne(t *testing.T) {
 	ttype := graphql.NewList(graphql.Int)
 	data := "Not an iterable"
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"test": nil,
-			},
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message:   "User Error: expected iterable, but did not find one for field DataType.test.",

--- a/mutations_test.go
+++ b/mutations_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -30,11 +31,11 @@ func (r *testRoot) ImmediatelyChangeTheNumber(newNumber int) *testNumberHolder {
 func (r *testRoot) PromiseToChangeTheNumber(newNumber int) *testNumberHolder {
 	return r.ImmediatelyChangeTheNumber(newNumber)
 }
-func (r *testRoot) FailToChangeTheNumber(newNumber int) *testNumberHolder {
-	panic("Cannot change the number")
+func (r *testRoot) FailToChangeTheNumber(newNumber int) (*testNumberHolder, error) {
+	return nil, errors.New("Cannot change the number")
 }
-func (r *testRoot) PromiseAndFailToChangeTheNumber(newNumber int) *testNumberHolder {
-	panic("Cannot change the number")
+func (r *testRoot) PromiseAndFailToChangeTheNumber(newNumber int) (*testNumberHolder, error) {
+	return nil, errors.New("Cannot change the number")
 }
 
 // numberHolderType creates a mapping to testNumberHolder
@@ -98,7 +99,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
-					return obj.FailToChangeTheNumber(newNumber), nil
+					return obj.FailToChangeTheNumber(newNumber)
 				},
 			},
 			"promiseAndFailToChangeTheNumber": &graphql.Field{
@@ -112,7 +113,7 @@ var mutationsTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
-					return obj.PromiseAndFailToChangeTheNumber(newNumber), nil
+					return obj.PromiseAndFailToChangeTheNumber(newNumber)
 				},
 			},
 		},
@@ -201,33 +202,12 @@ func TestMutations_EvaluatesMutationsCorrectlyInThePresenceOfAFailedMutation(t *
     }`
 
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"first": map[string]interface{}{
-				"theNumber": 1,
-			},
-			"second": map[string]interface{}{
-				"theNumber": 2,
-			},
-			"third": nil,
-			"fourth": map[string]interface{}{
-				"theNumber": 4,
-			},
-			"fifth": map[string]interface{}{
-				"theNumber": 5,
-			},
-			"sixth": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: `Cannot change the number`,
 				Locations: []location.SourceLocation{
 					{Line: 8, Column: 7},
-				},
-			},
-			{
-				Message: `Cannot change the number`,
-				Locations: []location.SourceLocation{
-					{Line: 17, Column: 7},
 				},
 			},
 		},

--- a/nonnull_test.go
+++ b/nonnull_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"errors"
 	"reflect"
 	"sort"
 	"testing"
@@ -16,18 +17,18 @@ var nonNullSyncError = "nonNullSync"
 var promiseError = "promise"
 var nonNullPromiseError = "nonNullPromise"
 
-var throwingData = map[string]interface{}{
-	"sync": func() interface{} {
-		panic(syncError)
+var erroringData = map[string]interface{}{
+	"sync": func() (interface{}, error) {
+		return nil, errors.New(syncError)
 	},
-	"nonNullSync": func() interface{} {
-		panic(nonNullSyncError)
+	"nonNullSync": func() (interface{}, error) {
+		return nil, errors.New(nonNullSyncError)
 	},
-	"promise": func() interface{} {
-		panic(promiseError)
+	"promise": func() (interface{}, error) {
+		return nil, errors.New(promiseError)
 	},
-	"nonNullPromise": func() interface{} {
-		panic(nonNullPromiseError)
+	"nonNullPromise": func() (interface{}, error) {
+		return nil, errors.New(nonNullPromiseError)
 	},
 }
 
@@ -69,17 +70,17 @@ var nonNullTestSchema, _ = graphql.NewSchema(graphql.SchemaConfig{
 })
 
 func init() {
-	throwingData["nest"] = func() interface{} {
-		return throwingData
+	erroringData["nest"] = func() interface{} {
+		return erroringData
 	}
-	throwingData["nonNullNest"] = func() interface{} {
-		return throwingData
+	erroringData["nonNullNest"] = func() interface{} {
+		return erroringData
 	}
-	throwingData["promiseNest"] = func() interface{} {
-		return throwingData
+	erroringData["promiseNest"] = func() interface{} {
+		return erroringData
 	}
-	throwingData["nonNullPromiseNest"] = func() interface{} {
-		return throwingData
+	erroringData["nonNullPromiseNest"] = func() interface{} {
+		return erroringData
 	}
 
 	nullingData["nest"] = func() interface{} {
@@ -117,9 +118,7 @@ func TestNonNull_NullsANullableFieldThatThrowsSynchronously(t *testing.T) {
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"sync": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: syncError,
@@ -138,7 +137,7 @@ func TestNonNull_NullsANullableFieldThatThrowsSynchronously(t *testing.T) {
 	ep := graphql.ExecuteParams{
 		Schema: nonNullTestSchema,
 		AST:    ast,
-		Root:   throwingData,
+		Root:   erroringData,
 	}
 	result := testutil.TestExecute(t, ep)
 	if len(result.Errors) != len(expected.Errors) {
@@ -155,9 +154,7 @@ func TestNonNull_NullsANullableFieldThatThrowsInAPromise(t *testing.T) {
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"promise": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: promiseError,
@@ -176,7 +173,7 @@ func TestNonNull_NullsANullableFieldThatThrowsInAPromise(t *testing.T) {
 	ep := graphql.ExecuteParams{
 		Schema: nonNullTestSchema,
 		AST:    ast,
-		Root:   throwingData,
+		Root:   erroringData,
 	}
 	result := testutil.TestExecute(t, ep)
 	if len(result.Errors) != len(expected.Errors) {
@@ -195,9 +192,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThat
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: nonNullSyncError,
@@ -216,7 +211,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThat
 	ep := graphql.ExecuteParams{
 		Schema: nonNullTestSchema,
 		AST:    ast,
-		Root:   throwingData,
+		Root:   erroringData,
 	}
 	result := testutil.TestExecute(t, ep)
 	if len(result.Errors) != len(expected.Errors) {
@@ -235,9 +230,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: nonNullPromiseError,
@@ -256,7 +249,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 	ep := graphql.ExecuteParams{
 		Schema: nonNullTestSchema,
 		AST:    ast,
-		Root:   throwingData,
+		Root:   erroringData,
 	}
 	result := testutil.TestExecute(t, ep)
 	if len(result.Errors) != len(expected.Errors) {
@@ -275,9 +268,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"promiseNest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: nonNullSyncError,
@@ -296,7 +287,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 	ep := graphql.ExecuteParams{
 		Schema: nonNullTestSchema,
 		AST:    ast,
-		Root:   throwingData,
+		Root:   erroringData,
 	}
 	result := testutil.TestExecute(t, ep)
 	if len(result.Errors) != len(expected.Errors) {
@@ -315,9 +306,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"promiseNest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: nonNullPromiseError,
@@ -336,7 +325,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 	ep := graphql.ExecuteParams{
 		Schema: nonNullTestSchema,
 		AST:    ast,
-		Root:   throwingData,
+		Root:   erroringData,
 	}
 	result := testutil.TestExecute(t, ep)
 	if len(result.Errors) != len(expected.Errors) {
@@ -377,103 +366,12 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": map[string]interface{}{
-				"sync":    nil,
-				"promise": nil,
-				"nest": map[string]interface{}{
-					"sync":    nil,
-					"promise": nil,
-				},
-				"promiseNest": map[string]interface{}{
-					"sync":    nil,
-					"promise": nil,
-				},
-			},
-			"promiseNest": map[string]interface{}{
-				"sync":    nil,
-				"promise": nil,
-				"nest": map[string]interface{}{
-					"sync":    nil,
-					"promise": nil,
-				},
-				"promiseNest": map[string]interface{}{
-					"sync":    nil,
-					"promise": nil,
-				},
-			},
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
-			{
-				Message: syncError,
-				Locations: []location.SourceLocation{
-					{Line: 4, Column: 11},
-				},
-			},
-			{
-				Message: syncError,
-				Locations: []location.SourceLocation{
-					{Line: 7, Column: 13},
-				},
-			},
-			{
-				Message: syncError,
-				Locations: []location.SourceLocation{
-					{Line: 11, Column: 13},
-				},
-			},
-			{
-				Message: syncError,
-				Locations: []location.SourceLocation{
-					{Line: 16, Column: 11},
-				},
-			},
-			{
-				Message: syncError,
-				Locations: []location.SourceLocation{
-					{Line: 19, Column: 13},
-				},
-			},
-			{
-				Message: syncError,
-				Locations: []location.SourceLocation{
-					{Line: 23, Column: 13},
-				},
-			},
-			{
-				Message: promiseError,
-				Locations: []location.SourceLocation{
-					{Line: 5, Column: 11},
-				},
-			},
 			{
 				Message: promiseError,
 				Locations: []location.SourceLocation{
 					{Line: 8, Column: 13},
-				},
-			},
-			{
-				Message: promiseError,
-				Locations: []location.SourceLocation{
-					{Line: 12, Column: 13},
-				},
-			},
-			{
-				Message: promiseError,
-				Locations: []location.SourceLocation{
-					{Line: 17, Column: 11},
-				},
-			},
-			{
-				Message: promiseError,
-				Locations: []location.SourceLocation{
-					{Line: 20, Column: 13},
-				},
-			},
-			{
-				Message: promiseError,
-				Locations: []location.SourceLocation{
-					{Line: 24, Column: 13},
 				},
 			},
 		},
@@ -485,7 +383,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 	ep := graphql.ExecuteParams{
 		Schema: nonNullTestSchema,
 		AST:    ast,
-		Root:   throwingData,
+		Root:   erroringData,
 	}
 	result := testutil.TestExecute(t, ep)
 	if len(result.Errors) != len(expected.Errors) {
@@ -550,35 +448,12 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest":               nil,
-			"promiseNest":        nil,
-			"anotherNest":        nil,
-			"anotherPromiseNest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
-			{
-				Message: nonNullSyncError,
-				Locations: []location.SourceLocation{
-					{Line: 8, Column: 19},
-				},
-			},
-			{
-				Message: nonNullSyncError,
-				Locations: []location.SourceLocation{
-					{Line: 19, Column: 19},
-				},
-			},
 			{
 				Message: nonNullPromiseError,
 				Locations: []location.SourceLocation{
 					{Line: 30, Column: 19},
-				},
-			},
-			{
-				Message: nonNullPromiseError,
-				Locations: []location.SourceLocation{
-					{Line: 41, Column: 19},
 				},
 			},
 		},
@@ -590,7 +465,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 	ep := graphql.ExecuteParams{
 		Schema: nonNullTestSchema,
 		AST:    ast,
-		Root:   throwingData,
+		Root:   erroringData,
 	}
 	result := testutil.TestExecute(t, ep)
 	if len(result.Errors) != len(expected.Errors) {
@@ -677,9 +552,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
@@ -715,9 +588,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
@@ -754,9 +625,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"promiseNest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
@@ -792,9 +661,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"promiseNest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
 			{
 				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
@@ -948,35 +815,12 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
       }
 	`
 	expected := &graphql.Result{
-		Data: map[string]interface{}{
-			"nest":               nil,
-			"promiseNest":        nil,
-			"anotherNest":        nil,
-			"anotherPromiseNest": nil,
-		},
+		Data: nil,
 		Errors: []gqlerrors.FormattedError{
-			{
-				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
-				Locations: []location.SourceLocation{
-					{Line: 8, Column: 19},
-				},
-			},
-			{
-				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
-				Locations: []location.SourceLocation{
-					{Line: 19, Column: 19},
-				},
-			},
 			{
 				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
 				Locations: []location.SourceLocation{
 					{Line: 30, Column: 19},
-				},
-			},
-			{
-				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
-				Locations: []location.SourceLocation{
-					{Line: 41, Column: 19},
 				},
 			},
 		},
@@ -1026,7 +870,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldThrows(t *testing.T) {
 	ep := graphql.ExecuteParams{
 		Schema: nonNullTestSchema,
 		AST:    ast,
-		Root:   throwingData,
+		Root:   erroringData,
 	}
 	result := testutil.TestExecute(t, ep)
 	if len(result.Errors) != len(expected.Errors) {
@@ -1058,7 +902,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldErrors(t *testing.T) {
 	ep := graphql.ExecuteParams{
 		Schema: nonNullTestSchema,
 		AST:    ast,
-		Root:   throwingData,
+		Root:   erroringData,
 	}
 	result := testutil.TestExecute(t, ep)
 	if len(result.Errors) != len(expected.Errors) {

--- a/values.go
+++ b/values.go
@@ -330,7 +330,7 @@ func isNullish(value interface{}) bool {
 	if value, ok := value.(float64); ok {
 		return math.IsNaN(value)
 	}
-	return value == nil
+	return !reflect.Indirect(reflect.ValueOf(value)).IsValid()
 }
 
 /**


### PR DESCRIPTION
- Don't use panic/recover to propagate errors
- Return immediately when an error occurs
- Execute request fields in deterministic order

\cc @titanous 
